### PR TITLE
Add hero scroll effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,17 @@
     <!-- future links: <a href="another.html">Another Tool</a> -->
   </nav>
 
-  <div class="content">
-    Welcome to Verdant Tools  
-  </div>
+  <section class="hero">
+    <h1 id="hero-title">Verdant Tools</h1>
+  </section>
+
+  <section class="image-section"></section>
+
+  <section class="info">
+    <h2>About Verdant Tools</h2>
+    <p>Verdant Tools provides a collection of CAD workflows to help you design your next project.</p>
+  </section>
+
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,6 @@
+const title = document.getElementById('hero-title');
+window.addEventListener('scroll', () => {
+  const maxScroll = window.innerHeight * 0.6;
+  const opacity = 1 - Math.min(window.scrollY / maxScroll, 1);
+  title.style.opacity = opacity;
+});

--- a/style.css
+++ b/style.css
@@ -2,13 +2,12 @@
 * { margin:0; padding:0; box-sizing:border-box; }
 body, html { height:100%; font-family: sans-serif; }
 
-/* Background image on homepage */
+/* Background color on homepage */
 .homepage {
-  background: url('images/background.png') no-repeat center center;
-  background-size: cover;
-  height:100%;
-  display: flex;
-  flex-direction: column;
+  background:#111;
+  min-height:100%;
+  display:flex;
+  flex-direction:column;
 }
 
 /* Top nav bar */
@@ -27,13 +26,36 @@ body, html { height:100%; font-family: sans-serif; }
   text-decoration: underline;
 }
 
-/* Content container */
-.content {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  text-shadow: 0 1px 3px rgba(0,0,0,0.7);
-  font-size: 2em;
+/* Hero section */
+.hero {
+  height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:#fff;
+  position:sticky;
+  top:0;
+  background:#111;
+}
+
+#hero-title {
+  font-size:3em;
+  text-shadow:0 1px 3px rgba(0,0,0,0.7);
+  transition:opacity 0.5s ease;
+}
+
+/* Background image section */
+.image-section {
+  height:100vh;
+  background:url('images/background.png') no-repeat center center/cover;
+  background-attachment:fixed;
+}
+
+/* Info section */
+.info {
+  padding:3em 1em;
+  max-width:800px;
+  margin:auto;
+  color:#fff;
+  line-height:1.6;
 }


### PR DESCRIPTION
## Summary
- redesign homepage sections
- create dark hero that fades out on scroll
- include parallax image section and extra info
- add Javascript to handle title fade effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c53c9c5908333b6c3d6ace9dfc12a